### PR TITLE
feature(ErrorLog): enhace error log readabiity

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,17 +127,22 @@ def write_contributors(repo, contributors_list, path, commit_message, CONTRIB):
     base = base.replace('\n', '')
     text = base64.b64decode(base).decode('utf-8')
     text_str = text.split(CONTRIB)
-    if re.match(head, text_str[1]):
-        end = text_str[1].split(tail)
-        end[0] = end[0] + tail
-    else:
-        end = ['', '\n\n' + text_str[1]]
-    if end[0] != contributors_list:
-        end[0] = contributors_list
-        text = text_str[0] + CONTRIB + end[0] + end[1]
-        repo.update_file(contents.path, commit_message, text, contents.sha)
-    else:
-        pass
+    try:
+        if re.match(head, text_str[1]):
+            end = text_str[1].split(tail)
+            end[0] = end[0] + tail
+        else:
+            end = ['', '\n\n' + text_str[1]]
+        if end[0] != contributors_list:
+            end[0] = contributors_list
+            text = text_str[0] + CONTRIB + end[0] + end[1]
+            repo.update_file(contents.path, commit_message, text, contents.sha)
+        else:
+            pass
+    except IndexError:
+        raise Exception("The file where contributors are trying to be written '" + path + "' does not have '" + CONTRIB +"' section")
+    except(RuntimeError, TypeError, NameError):
+        raise Exception(NameError)
 
 
 def main():


### PR DESCRIPTION
## Description
<!--- Why is this change required? What problem does it solve?-->
Raises a problem related with the context, and not general "IndexError"
<!--- Describe your changes in detail here to communicate to the maintainers why this pull request should be accepted-->
Just updated main.py, added try catch from main.py#L130 to main.py#L140
<!--- If it fixes an open issue, please link to the issue here in the last line.-->
Resolves: #6 

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes locally -->
forked repo, created .github/workflows/main.yml based on .github/workflows/contributors.yml, updated steps and REPO_NAME with my github username, as well as triggering on each push. Then ran tests changing CONTRIBUTOR with sections present and not in the README file to check if IndexError was catched and raised with the context error.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- For example, markdown files should pass markdownlint locally according to the rules -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots(optional)
<!--- If Screenshots is not necessary or not available in this pull request, you can delete this section -->
<!--- Changes including html and css are required to have screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? -->

<!--- Only left the line that best describes this pull request -->
- Other (please describe here):Error log enhacement

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Code follows the code style of this project.
- [x] Changes follow the **CONTRIBUTING** guidelines.
- [x] Update necessary documentation accordingly.
- [x] Lint and tests pass locally with the changes.
- [x] Check issues and pull requests first. You don't want to duplicate effort.

## Other information
